### PR TITLE
Set up three different implementations of radiation pressure.

### DIFF
--- a/src/main/java/org/orekit/forces/BoxAndSolarArraySpacecraft.java
+++ b/src/main/java/org/orekit/forces/BoxAndSolarArraySpacecraft.java
@@ -55,9 +55,6 @@ import org.orekit.utils.PVCoordinatesProvider;
  * <p>
  * This model does not take cast shadow between body and solar array into account.
  * </p>
- * <p>
- * Instances of this class are guaranteed to be immutable.
- * </p>
  *
  * @see SphericalSpacecraft
  * @author Luc Maisonobe

--- a/src/main/java/org/orekit/forces/drag/IsotropicDrag.java
+++ b/src/main/java/org/orekit/forces/drag/IsotropicDrag.java
@@ -1,0 +1,101 @@
+/* Copyright 2002-2016 CS Systèmes d'Information
+ * Licensed to CS Systèmes d'Information (CS) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * CS licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.orekit.forces.drag;
+
+import org.apache.commons.math3.analysis.differentiation.DerivativeStructure;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldRotation;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldVector3D;
+import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+import org.orekit.errors.OrekitException;
+import org.orekit.errors.OrekitMessages;
+import org.orekit.forces.drag.DragSensitive;
+import org.orekit.frames.Frame;
+import org.orekit.time.AbsoluteDate;
+
+/** This class models isotropic drag effects.
+ * <p>The model of this spacecraft is a simple spherical model, this
+ * means that all coefficients are constant and do not depend of
+ * the direction.</p>
+ *
+ * @see org.orekit.forces.BoxAndSolarArraySpacecraft
+ * @see org.orekit.forces.radiation.IsotropicRadiationCNES95Convention
+ * @author Luc Maisonobe
+ * @since 7.1
+ */
+public class IsotropicDrag implements DragSensitive {
+
+    /** Cross section (m²). */
+    private final double crossSection;
+
+    /** Drag coefficient. */
+    private double dragCoeff;
+
+    /** Simple constructor.
+     * @param crossSection Surface (m²)
+     * @param dragCoeff drag coefficient
+     */
+    public IsotropicDrag(final double crossSection, final double dragCoeff) {
+        this.crossSection = crossSection;
+        this.dragCoeff    = dragCoeff;
+    }
+
+    /** {@inheritDoc} */
+    public Vector3D dragAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                     final Rotation rotation, final double mass,
+                                     final double density, final Vector3D relativeVelocity) {
+        return new Vector3D(relativeVelocity.getNorm() * density * dragCoeff * crossSection / (2 * mass),
+                            relativeVelocity);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> dragAcceleration(final AbsoluteDate date, final Frame frame, final FieldVector3D<DerivativeStructure> position,
+                                                               final FieldRotation<DerivativeStructure> rotation, final DerivativeStructure mass,
+                                                               final DerivativeStructure density, final FieldVector3D<DerivativeStructure> relativeVelocity) {
+        return new FieldVector3D<DerivativeStructure>(relativeVelocity.getNorm().multiply(density.multiply(dragCoeff * crossSection / 2)).divide(mass),
+                              relativeVelocity);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> dragAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                                               final Rotation rotation, final double mass,
+                                                               final  double density, final Vector3D relativeVelocity,
+                                                               final String paramName)
+        throws OrekitException {
+
+        if (!DRAG_COEFFICIENT.equals(paramName)) {
+            throw new OrekitException(OrekitMessages.UNSUPPORTED_PARAMETER_NAME, paramName, DRAG_COEFFICIENT);
+        }
+
+        final DerivativeStructure dragCoeffDS = new DerivativeStructure(1, 1, 0, dragCoeff);
+
+        return new FieldVector3D<DerivativeStructure>(dragCoeffDS.multiply(relativeVelocity.getNorm() * density * crossSection / (2 * mass)),
+                              relativeVelocity);
+
+    }
+
+    /** {@inheritDoc} */
+    public void setDragCoefficient(final double value) {
+        dragCoeff = value;
+    }
+
+    /** {@inheritDoc} */
+    public double getDragCoefficient() {
+        return dragCoeff;
+    }
+
+}

--- a/src/main/java/org/orekit/forces/radiation/IsotropicRadiationCNES95Convention.java
+++ b/src/main/java/org/orekit/forces/radiation/IsotropicRadiationCNES95Convention.java
@@ -1,0 +1,140 @@
+/* Copyright 2002-2016 CS Systèmes d'Information
+ * Licensed to CS Systèmes d'Information (CS) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * CS licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.orekit.forces.radiation;
+
+import org.apache.commons.math3.analysis.differentiation.DerivativeStructure;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldRotation;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldVector3D;
+import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+import org.orekit.errors.OrekitException;
+import org.orekit.errors.OrekitMessages;
+import org.orekit.forces.radiation.RadiationSensitive;
+import org.orekit.frames.Frame;
+import org.orekit.time.AbsoluteDate;
+
+/** This class represents the features of a simplified spacecraft.
+ * <p>This model uses the coefficients described in the collective
+ * book edited by CNES in 1995: Spaceflight Dynamics (part I), in
+ * section 5.2.2.1.3.1 (page 296 of the English edition). The absorption
+ * coefficient is called α and the specular reflection coefficient is
+ * called τ. A comment in section 5.2.2.1.3.2 of the same book reads:
+ * <pre>
+ * Some authors prefer to express thermo-optical properties for surfaces
+ * using the following coefficients: Ka = α, Ks = (1-α)τ, Kd = (1-α)(1-τ)
+ * </pre>
+ * Ka is the same absorption coefficient, and Ks is also called specular
+ * reflection coefficient, which leads to a confusion. In fact, as the Ka,
+ * Ks and Kd coefficients are the most frequently used ones (using the
+ * names Ca, Cs and Cd), when speaking about reflection coefficients, it
+ * is more often Cd that is considered rather than τ.
+ * </p>
+ * <p>
+ * The classical set of coefficients Ca, Cs, and Cd are implemented in the
+ * sister class {@link IsotropicRadiationClassicalConvention}, which should
+ * probably be preferred to this legacy class.
+ * </p>
+ *
+ * @see org.orekit.forces.BoxAndSolarArraySpacecraft
+ * @see org.orekit.forces.drag.IsotropicDrag
+ * @see IsotropicRadiationClassicalConvention
+ * @author Luc Maisonobe
+ * @since 7.1
+ */
+public class IsotropicRadiationCNES95Convention implements RadiationSensitive {
+
+    /** Cross section (m²). */
+    private final double crossSection;
+
+    /** Absorption coefficient. */
+    private double alpha;
+
+    /** Specular reflection coefficient. */
+    private double tau;
+
+    /** Simple constructor.
+     * @param crossSection Surface (m²)
+     * @param alpha absorption coefficient α between 0.0 an 1.0
+     * @param tau specular reflection coefficient τ between 0.0 an 1.0
+     */
+    public IsotropicRadiationCNES95Convention(final double crossSection, final double alpha, final double tau) {
+        this.crossSection = crossSection;
+        this.alpha        = alpha;
+        this.tau          = tau;
+    }
+
+    /** {@inheritDoc} */
+    public Vector3D radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                                  final Rotation rotation, final double mass, final Vector3D flux) {
+        final double kP = crossSection * (1 + 4 * (1.0 - alpha) * (1.0 - tau) / 9.0);
+        return new Vector3D(kP / mass, flux);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final FieldVector3D<DerivativeStructure> position,
+                                                                            final FieldRotation<DerivativeStructure> rotation, final DerivativeStructure mass,
+                                                                            final FieldVector3D<DerivativeStructure> flux) {
+        final double kP = crossSection * (1 + 4 * (1.0 - alpha) * (1.0 - tau) / 9.0);
+        return new FieldVector3D<DerivativeStructure>(mass.reciprocal().multiply(kP), flux);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                                                            final Rotation rotation, final double mass,
+                                                                            final Vector3D flux, final String paramName)
+        throws OrekitException {
+
+        final DerivativeStructure absorptionCoeffDS;
+        final DerivativeStructure specularReflectionCoeffDS;
+        if (ABSORPTION_COEFFICIENT.equals(paramName)) {
+            absorptionCoeffDS         = new DerivativeStructure(1, 1, 0, alpha);
+            specularReflectionCoeffDS = new DerivativeStructure(1, 1,    tau);
+        } else if (REFLECTION_COEFFICIENT.equals(paramName)) {
+            absorptionCoeffDS         = new DerivativeStructure(1, 1,    alpha);
+            specularReflectionCoeffDS = new DerivativeStructure(1, 1, 0, tau);
+        } else {
+            throw new OrekitException(OrekitMessages.UNSUPPORTED_PARAMETER_NAME, paramName,
+                                      ABSORPTION_COEFFICIENT + ", " + REFLECTION_COEFFICIENT);
+        }
+
+        final DerivativeStructure kP =
+                absorptionCoeffDS.subtract(1).multiply(specularReflectionCoeffDS.subtract(1)).multiply(4.0 / 9.0).add(1).multiply(crossSection);
+        return new FieldVector3D<DerivativeStructure>(kP.divide(mass), flux);
+
+    }
+
+    /** {@inheritDoc} */
+    public void setAbsorptionCoefficient(final double value) {
+        alpha = value;
+    }
+
+    /** {@inheritDoc} */
+    public double getAbsorptionCoefficient() {
+        return alpha;
+    }
+
+    /** {@inheritDoc} */
+    public void setReflectionCoefficient(final double value) {
+        tau = value;
+    }
+
+    /** {@inheritDoc} */
+    public double getReflectionCoefficient() {
+        return tau;
+    }
+
+}

--- a/src/main/java/org/orekit/forces/radiation/IsotropicRadiationClassicalConvention.java
+++ b/src/main/java/org/orekit/forces/radiation/IsotropicRadiationClassicalConvention.java
@@ -1,0 +1,129 @@
+/* Copyright 2002-2016 CS Systèmes d'Information
+ * Licensed to CS Systèmes d'Information (CS) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * CS licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.orekit.forces.radiation;
+
+import org.apache.commons.math3.analysis.differentiation.DerivativeStructure;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldRotation;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldVector3D;
+import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+import org.orekit.errors.OrekitException;
+import org.orekit.errors.OrekitMessages;
+import org.orekit.forces.radiation.RadiationSensitive;
+import org.orekit.frames.Frame;
+import org.orekit.time.AbsoluteDate;
+
+/** This class represents the features of a simplified spacecraft.
+ * <p>This model uses the classical thermo-optical coefficients
+ * Ca for absorption, Cs for specular reflection and Kd for diffuse
+ * reflection. The equation Ca + Cs + Cd = 1 always holds.
+ * </p>
+ * <p>
+ * A less standard set of coefficients α = Ca for absorption and
+ * τ = Cs/(1-Ca) for specular reflection is implemented in the sister
+ * class {@link IsotropicRadiationCNES95Convention}.
+ * </p>
+ *
+ * @see org.orekit.forces.BoxAndSolarArraySpacecraft
+ * @see org.orekit.forces.drag.IsotropicDrag
+ * @see IsotropicRadiationCNES95Convention
+ * @author Luc Maisonobe
+ * @since 7.1
+ */
+public class IsotropicRadiationClassicalConvention implements RadiationSensitive {
+
+    /** Cross section (m²). */
+    private final double crossSection;
+
+    /** Absorption coefficient. */
+    private double ca;
+
+    /** Specular reflection coefficient. */
+    private double cs;
+
+    /** Simple constructor.
+     * @param crossSection Surface (m²)
+     * @param ca absorption coefficient Ca between 0.0 an 1.0
+     * @param cs specular reflection coefficient Cs between 0.0 an 1.0
+     */
+    public IsotropicRadiationClassicalConvention(final double crossSection, final double ca, final double cs) {
+        this.crossSection = crossSection;
+        this.ca           = ca;
+        this.cs           = cs;
+    }
+
+    /** {@inheritDoc} */
+    public Vector3D radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                                  final Rotation rotation, final double mass, final Vector3D flux) {
+        final double kP = crossSection * (1 + 4 * (1.0 - ca - cs) / 9.0);
+        return new Vector3D(kP / mass, flux);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final FieldVector3D<DerivativeStructure> position,
+                                                                            final FieldRotation<DerivativeStructure> rotation, final DerivativeStructure mass,
+                                                                            final FieldVector3D<DerivativeStructure> flux) {
+        final double kP = crossSection * (1 + 4 * (1.0 - ca - cs) / 9.0);
+        return new FieldVector3D<DerivativeStructure>(mass.reciprocal().multiply(kP), flux);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                                                            final Rotation rotation, final double mass,
+                                                                            final Vector3D flux, final String paramName)
+        throws OrekitException {
+
+        final DerivativeStructure caDS;
+        final DerivativeStructure csDS;
+        if (ABSORPTION_COEFFICIENT.equals(paramName)) {
+            caDS = new DerivativeStructure(1, 1, 0, ca);
+            csDS = new DerivativeStructure(1, 1,    cs);
+        } else if (REFLECTION_COEFFICIENT.equals(paramName)) {
+            caDS = new DerivativeStructure(1, 1,    ca);
+            csDS = new DerivativeStructure(1, 1, 0, cs);
+        } else {
+            throw new OrekitException(OrekitMessages.UNSUPPORTED_PARAMETER_NAME, paramName,
+                                      ABSORPTION_COEFFICIENT + ", " + REFLECTION_COEFFICIENT);
+        }
+
+        final DerivativeStructure kP =
+                caDS.add(csDS).subtract(1).multiply(-4.0 / 9.0).add(1).multiply(crossSection);
+        return new FieldVector3D<DerivativeStructure>(kP.divide(mass), flux);
+
+    }
+
+    /** {@inheritDoc} */
+    public void setAbsorptionCoefficient(final double value) {
+        ca = value;
+    }
+
+    /** {@inheritDoc} */
+    public double getAbsorptionCoefficient() {
+        return ca;
+    }
+
+    /** {@inheritDoc} */
+    public void setReflectionCoefficient(final double value) {
+        cs = value;
+    }
+
+    /** {@inheritDoc} */
+    public double getReflectionCoefficient() {
+        return cs;
+    }
+
+}

--- a/src/main/java/org/orekit/forces/radiation/IsotropicRadiationSingleCoefficient.java
+++ b/src/main/java/org/orekit/forces/radiation/IsotropicRadiationSingleCoefficient.java
@@ -1,0 +1,120 @@
+/* Copyright 2002-2016 CS Systèmes d'Information
+ * Licensed to CS Systèmes d'Information (CS) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * CS licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.orekit.forces.radiation;
+
+import org.apache.commons.math3.analysis.differentiation.DerivativeStructure;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldRotation;
+import org.apache.commons.math3.geometry.euclidean.threed.FieldVector3D;
+import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+import org.orekit.errors.OrekitException;
+import org.orekit.errors.OrekitMessages;
+import org.orekit.forces.radiation.RadiationSensitive;
+import org.orekit.frames.Frame;
+import org.orekit.time.AbsoluteDate;
+
+/** This class represents the features of a simplified spacecraft.
+ * <p>This model uses a single coefficient cr, considered to be
+ * a {@link RadiationSensitive#REFLECTION_COEFFICIENT}.
+ * </p>
+ *
+ * @see org.orekit.forces.BoxAndSolarArraySpacecraft
+ * @see org.orekit.forces.drag.IsotropicDrag
+ * @see IsotropicRadiationCNES95Convention
+ * @author Luc Maisonobe
+ * @since 7.1
+ */
+public class IsotropicRadiationSingleCoefficient implements RadiationSensitive {
+
+    /** Cross section (m²). */
+    private final double crossSection;
+
+    /** Reflection coefficient. */
+    private double cr;
+
+    /** Simple constructor.
+     * @param crossSection Surface (m²)
+     * @param cr reflection coefficient
+     */
+    public IsotropicRadiationSingleCoefficient(final double crossSection, final double cr) {
+        this.crossSection = crossSection;
+        this.cr           = cr;
+    }
+
+    /** {@inheritDoc} */
+    public Vector3D radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                                  final Rotation rotation, final double mass, final Vector3D flux) {
+        return new Vector3D(crossSection * cr / mass, flux);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final FieldVector3D<DerivativeStructure> position,
+                                                                            final FieldRotation<DerivativeStructure> rotation, final DerivativeStructure mass,
+                                                                            final FieldVector3D<DerivativeStructure> flux) {
+        return new FieldVector3D<DerivativeStructure>(mass.reciprocal().multiply(crossSection * cr), flux);
+    }
+
+    /** {@inheritDoc} */
+    public FieldVector3D<DerivativeStructure> radiationPressureAcceleration(final AbsoluteDate date, final Frame frame, final Vector3D position,
+                                                                            final Rotation rotation, final double mass,
+                                                                            final Vector3D flux, final String paramName)
+        throws OrekitException {
+
+        final DerivativeStructure crDS;
+        if (REFLECTION_COEFFICIENT.equals(paramName)) {
+            crDS = new DerivativeStructure(1, 1, 0, cr);
+        } else {
+            throw new OrekitException(OrekitMessages.UNSUPPORTED_PARAMETER_NAME, paramName,
+                                      ABSORPTION_COEFFICIENT + ", " + REFLECTION_COEFFICIENT);
+        }
+
+        return new FieldVector3D<DerivativeStructure>(crDS.multiply(crossSection / mass), flux);
+
+    }
+
+    /** {@inheritDoc}
+     * <p>
+     * As there are no absorption coefficients, this method
+     * throws an {@link UnsupportedOperationException}.
+     * </p>
+     */
+    public void setAbsorptionCoefficient(final double value)
+        throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    /** {@inheritDoc}
+     * <p>
+     * As there are no absorption coefficients, this method
+     * always returns 0.0.
+     * </p>
+     */
+    public double getAbsorptionCoefficient() {
+        return 0;
+    }
+
+    /** {@inheritDoc} */
+    public void setReflectionCoefficient(final double value) {
+        cr = value;
+    }
+
+    /** {@inheritDoc} */
+    public double getReflectionCoefficient() {
+        return cr;
+    }
+
+}

--- a/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTAtmosphericDrag.java
+++ b/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTAtmosphericDrag.java
@@ -19,10 +19,10 @@ package org.orekit.propagation.semianalytical.dsst.forces;
 import org.apache.commons.math3.util.FastMath;
 import org.apache.commons.math3.util.MathUtils;
 import org.orekit.errors.OrekitException;
-import org.orekit.forces.SphericalSpacecraft;
 import org.orekit.forces.drag.Atmosphere;
 import org.orekit.forces.drag.DragForce;
 import org.orekit.forces.drag.DragSensitive;
+import org.orekit.forces.drag.IsotropicDrag;
 import org.orekit.propagation.SpacecraftState;
 import org.orekit.propagation.events.EventDetector;
 import org.orekit.utils.Constants;
@@ -60,8 +60,7 @@ public class DSSTAtmosphericDrag extends AbstractGaussianContribution {
      */
     public DSSTAtmosphericDrag(final Atmosphere atmosphere, final double cd,
             final double area) {
-        this(atmosphere, new SphericalSpacecraft(
-                area, cd, 0.0, 0.0));
+        this(atmosphere, new IsotropicDrag(area, cd));
     }
 
     /** Simple constructor with custom spacecraft.

--- a/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTSolarRadiationPressure.java
+++ b/src/main/java/org/orekit/propagation/semianalytical/dsst/forces/DSSTSolarRadiationPressure.java
@@ -21,7 +21,7 @@ import org.apache.commons.math3.util.FastMath;
 import org.apache.commons.math3.util.MathUtils;
 import org.apache.commons.math3.util.Precision;
 import org.orekit.errors.OrekitException;
-import org.orekit.forces.SphericalSpacecraft;
+import org.orekit.forces.radiation.IsotropicRadiationSingleCoefficient;
 import org.orekit.forces.radiation.RadiationSensitive;
 import org.orekit.forces.radiation.SolarRadiationPressure;
 import org.orekit.propagation.SpacecraftState;
@@ -131,8 +131,7 @@ public class DSSTSolarRadiationPressure extends AbstractGaussianContribution {
         // the conversion is:
         // cR = 1 + (1 - kA) * (1 - kR) * 4 / 9
         // with kA arbitrary sets to 0
-        this(dRef, pRef, sun, equatorialRadius, new SphericalSpacecraft(
-                area, 0.0, 0.0, 3.25 - 2.25 * cr));
+        this(dRef, pRef, sun, equatorialRadius, new IsotropicRadiationSingleCoefficient(area, cr));
     }
 
     /**

--- a/src/site/xdoc/changes.xml
+++ b/src/site/xdoc/changes.xml
@@ -21,6 +21,14 @@
   </properties>
   <body>
     <release version="7.1" date="TBD" description="TBD">
+      <action dev="luc" type="add">
+        Set up three different implementations of radiation pressure coefficients,
+        using either a single reflection coefficient, or a pair of absorption
+        and specular reflection coefficients using the classical convention about
+        specular reflection, or a pair of absorption and specular reflection
+        coefficients using the legacy convention from the 1995 CNES book.
+        Fixes issue #170
+      </action>
       <action dev="luc" type="fix">
         Fixed wrong latitude normalization in FieldGeodeticPoint.
       </action>

--- a/src/test/java/org/orekit/forces/SphericalSpacecraftTest.java
+++ b/src/test/java/org/orekit/forces/SphericalSpacecraftTest.java
@@ -32,6 +32,7 @@ import org.orekit.time.DateComponents;
 import org.orekit.time.TimeComponents;
 import org.orekit.time.TimeScalesFactory;
 
+@Deprecated
 public class SphericalSpacecraftTest {
 
     @Test

--- a/src/test/java/org/orekit/forces/drag/DragForceTest.java
+++ b/src/test/java/org/orekit/forces/drag/DragForceTest.java
@@ -31,7 +31,6 @@ import org.orekit.bodies.OneAxisEllipsoid;
 import org.orekit.errors.OrekitException;
 import org.orekit.forces.AbstractForceModelTest;
 import org.orekit.forces.BoxAndSolarArraySpacecraft;
-import org.orekit.forces.SphericalSpacecraft;
 import org.orekit.frames.Frame;
 import org.orekit.frames.FramesFactory;
 import org.orekit.orbits.CartesianOrbit;
@@ -69,7 +68,7 @@ public class DragForceTest extends AbstractForceModelTest {
                                                  new OneAxisEllipsoid(Constants.WGS84_EARTH_EQUATORIAL_RADIUS,
                                                                       Constants.WGS84_EARTH_FLATTENING,
                                                                       FramesFactory.getITRF(IERSConventions.IERS_2010, true))),
-                              new SphericalSpacecraft(2.5, 1.2, 0.7, 0.2));
+                              new IsotropicDrag(2.5, 1.2));
 
         checkParameterDerivative(state, forceModel, DragSensitive.DRAG_COEFFICIENT, 1.0e-4, 2.0e-12);
 
@@ -101,7 +100,7 @@ public class DragForceTest extends AbstractForceModelTest {
                                                  new OneAxisEllipsoid(Constants.WGS84_EARTH_EQUATORIAL_RADIUS,
                                                                       Constants.WGS84_EARTH_FLATTENING,
                                                                       FramesFactory.getITRF(IERSConventions.IERS_2010, true))),
-                              new SphericalSpacecraft(2.5, 1.2, 0.7, 0.2));
+                              new IsotropicDrag(2.5, 1.2));
         propagator.addForceModel(forceModel);
         SpacecraftState state0 = new SpacecraftState(orbit);
 
@@ -184,7 +183,7 @@ public class DragForceTest extends AbstractForceModelTest {
                                                   inc, aop, raan, mean, PositionAngle.MEAN,
                                                   frame, initialDate, Constants.EIGEN5C_EARTH_MU);
 
-        SphericalSpacecraft shape = new SphericalSpacecraft(10., 2.2, 0., 0.);
+        IsotropicDrag shape = new IsotropicDrag(10., 2.2);
 
         Frame itrf = FramesFactory.getITRF(IERSConventions.IERS_2010, true);
         BodyShape earthShape = new OneAxisEllipsoid(Constants.WGS84_EARTH_EQUATORIAL_RADIUS, Constants.WGS84_EARTH_FLATTENING, itrf);

--- a/src/test/java/org/orekit/propagation/conversion/NumericalConverterTest.java
+++ b/src/test/java/org/orekit/propagation/conversion/NumericalConverterTest.java
@@ -36,10 +36,10 @@ import org.orekit.errors.OrekitException;
 import org.orekit.errors.OrekitIllegalArgumentException;
 import org.orekit.errors.OrekitMessages;
 import org.orekit.forces.ForceModel;
-import org.orekit.forces.SphericalSpacecraft;
 import org.orekit.forces.drag.Atmosphere;
 import org.orekit.forces.drag.DragForce;
 import org.orekit.forces.drag.DragSensitive;
+import org.orekit.forces.drag.IsotropicDrag;
 import org.orekit.forces.drag.SimpleExponentialAtmosphere;
 import org.orekit.forces.gravity.HolmesFeatherstoneAttractionModel;
 import org.orekit.forces.gravity.NewtonianAttraction;
@@ -369,8 +369,7 @@ public class NumericalConverterTest {
         earth.setAngularThreshold(1.e-7);
         final Atmosphere atmosphere = new SimpleExponentialAtmosphere(earth, 0.0004, 42000.0, 7500.0);
         final double dragCoef = 2.0;
-        final SphericalSpacecraft ss = new SphericalSpacecraft(10., dragCoef, 0., 0.);
-        drag = new DragForce(atmosphere, ss);
+        drag = new DragForce(atmosphere, new IsotropicDrag(10., dragCoef));
 
         propagator.addForceModel(gravity);
         propagator.addForceModel(drag);


### PR DESCRIPTION
The first implementation uses a single reflection coefficient.
The second implementation uses a pair of absorption and specular
reflection coefficients using the classical convention about
specular reflection.
The third implementation uses a pair of absorption and specular
reflection coefficients using the legacy convention from the 1995
CNES book.

Fixes issue #170